### PR TITLE
Remove min files from bower main.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "Dan Tocchini <d4@thegrid.io>"
   ],
   "description": "Grid Style Sheets Runtime",
-  "main": ["dist/gss.js","dist/gss.min.js","dist/worker.js","dist/worker.min.js"],
+  "main": ["dist/worker.js","dist/gss.js"],
   "keywords": [
     "gss"
   ],


### PR DESCRIPTION
As per the spec for Bower, don't include minified files for `main` property, (and especially not both!) See bower/bower#393 for more.

In real-world use, I use a build script that uses the main property, and this fix fixes an error that includes both versions of the file where I would only want the min file.