### PR TITLE
Add grunt-cli as a dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-exec": "~0.4.0",
     "component": "~0.19.5",
-    "grunt-banner": "^0.2.1"
+    "grunt-banner": "^0.2.1",
+    "grunt-cli": "~0.1.13"
   },
   "keywords": [],
   "scripts": {
-    "test": "grunt test"
+    "test": "node_modules/.bin/grunt test"
   },
   "main": "./lib/Engine",
   "dependencies": {


### PR DESCRIPTION
Allows tests to be run via `npm run-script test` immediately after `npm install` and without needing to install grunt globally.