### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing Guidelines
+
+Guidelines for contributing to GSS.
+
+
+## Issues
+
+Issues are most appropriate for bugs and other problems encountered using GSS. Ideally, include a demo project (GitHub repo, CodePen, JSFiddle, etc) that focuses on the issue.
+
+Please search existing issues before filing new ones.
+
+
+## Pull requests
+
+Pull requests should be issued from dedicated branches, as opposed to `master`.
+
+It may be worth opening an issue to discuss feature requests and major changes before attemping to implement them.
+
+Prefixing a pull request will `[WIP]` and committing early is a good way to get feedback without too much investment.
+
+
+## Questions
+
+When questions are asked, consider providing an answer by opening a pull request against the GSS documentation.
+
+
+## Dependencies
+
+Dependencies should be referenced by an appropriate version number or tag and never by overly-permissive references such as branch names or `*`. In the case that a dependency has no available versions or tags, use a git commit SHA.
+
+
+## Releases
+
+Releases should always be made from `master` and follow [semantic versioning](http://semver.org/).
+
+References in code to the version number should be updated before building for distribution and tagging a new release.
+
+Prefer using the [GitHub UI](https://github.com/gss/engine/releases/new) and provide useful release notes.
+
+Lastly, releases should be published to npm by running `npm publish`.


### PR DESCRIPTION
I've added a [CONTRIBUTING.md](https://github.com/blog/1184-contributing-guidelines) which triggers a prompt like this when creating issues and pull requests:

![contributing](https://camo.githubusercontent.com/71995d6b0e620a9ef1ded00a04498241c69dd1bf/68747470733a2f2f6769746875622d696d616765732e73332e616d617a6f6e6177732e636f6d2f736b697463682f6973737565732d32303132303931332d3136323533392e6a7067)

This relates to #133.

Please review! :raised_hands: