### PR TITLE
Tests: Add smoketest for node.js

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -102,6 +102,14 @@ module.exports = ->
           base: ''
           port: 9999
 
+    # BDD tests on node.js
+    mochaTest:
+      nodejs:
+        src: ['spec/nodejs/*.coffee']
+        options:
+          reporter: 'spec'
+
+
     # BDD tests on browser
     mocha_phantomjs:
       all:
@@ -159,6 +167,7 @@ module.exports = ->
   @loadNpmTasks 'grunt-coffeelint'
   @loadNpmTasks 'grunt-mocha-phantomjs'
   @loadNpmTasks 'grunt-contrib-watch'
+  @loadNpmTasks 'grunt-mocha-test'
 
   # Cross-browser testing in the cloud
   @loadNpmTasks 'grunt-contrib-connect'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-contrib-uglify": "~0.2.1",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-connect": "~0.3.0",
+    "grunt-mocha-test": "^0.11.0",
     "grunt-docco": "^0.3.3",
     "grunt-mocha-phantomjs": "~0.4.0",
     "grunt-saucelabs": "^8.4.1"

--- a/spec/nodejs/smoke.coffee
+++ b/spec/nodejs/smoke.coffee
@@ -1,0 +1,32 @@
+
+chai = require 'chai' if not chai?
+assert = chai.assert
+expect = chai.expect
+
+Engine = require('../../src/Engine.coffee');
+
+describe 'On node.js', ->
+  engine = null
+
+  beforeEach ->
+    engine = new Engine()
+    return
+  afterEach ->
+    engine.destroy() if engine
+    engine = null
+
+  describe 'single solving domain', ->
+    it 'should find solutions', ->
+      expect(engine.solve [
+        ['==',
+          ['get', 'result']
+          ['+',
+            ['get', 'a']
+            1
+          ]
+        ]
+      ]).to.eql 
+        result: 0
+        a: -1
+
+


### PR DESCRIPTION
Should eventually be running all tests which don't rely on DOM under node.js, but this is a start